### PR TITLE
Python 3.6, aiohttp3 enhancements, less noisy log

### DIFF
--- a/asyncnsq/connection.py
+++ b/asyncnsq/connection.py
@@ -180,10 +180,9 @@ class NsqConnection:
         while not self._reader.at_eof():
             try:
                 data = await self._reader.read(52)
-            except asyncio.CancelledError as tmp:
+            except asyncio.CancelledError:
                 is_canceled = True
-                logger.error('Task is canceled')
-                logger.exception(tmp)
+                logger.debug('Task is canceled')
                 break
             except Exception as exc:
                 logger.exception(exc)

--- a/asyncnsq/consumer.py
+++ b/asyncnsq/consumer.py
@@ -71,10 +71,10 @@ class NsqConsumer:
                 logger.debug(('host, port', host, port))
                 conn = await create_nsq(host, port, queue=self._queue,
                                         loop=self._loop)
-                print('conn.id:', conn.id)
+                logger.debug('conn.id:', conn.id)
                 self._connections[conn.id] = conn
                 self._rdy_control.add_connection(conn)
-        nsqlookup_conn.close()
+        await nsqlookup_conn.close()
 
     async def lookupd_task_done_sub(self, topic, channel):
         for conn in self._connections.values():

--- a/asyncnsq/consumer.py
+++ b/asyncnsq/consumer.py
@@ -6,7 +6,8 @@ import logging
 from asyncnsq.http import NsqLookupd
 from asyncnsq.nsq import create_nsq
 from asyncnsq.utils import RdyControl
-logger = logging.getLogger()
+
+logger = logging.getLogger(__name__)
 
 
 class NsqConsumer:
@@ -55,8 +56,8 @@ class NsqConsumer:
         nsqlookup_conn = NsqLookupd(host, port, loop=self._loop)
         try:
             res = await nsqlookup_conn.lookup(self.topic)
-            logger.info('lookupd response')
-            logger.info(res)
+            logger.debug('lookupd response')
+            logger.debug(res)
         except Exception as tmp:
             logger.error(tmp)
             logger.exception(tmp)
@@ -67,7 +68,7 @@ class NsqConsumer:
             port = producer['tcp_port']
             tmp_id = "tcp://{}:{}".format(host, port)
             if tmp_id not in self._connections:
-                logger.info(('host, port', host, port))
+                logger.debug(('host, port', host, port))
                 conn = await create_nsq(host, port, queue=self._queue,
                                         loop=self._loop)
                 print('conn.id:', conn.id)

--- a/asyncnsq/http/base.py
+++ b/asyncnsq/http/base.py
@@ -21,8 +21,8 @@ class NsqHTTPConnection:
     def endpoint(self):
         return 'http://{0}:{1}'.format(*self._endpoint)
 
-    def close(self):
-        self._session.close()
+    async def close(self):
+        return await self._session.close()
 
     async def perform_request(self, method, url, params, body):
         _body = _convert_to_str(body) if body else body

--- a/asyncnsq/http/base.py
+++ b/asyncnsq/http/base.py
@@ -14,8 +14,8 @@ class NsqHTTPConnection:
         self._endpoint = (host, port)
         self._base_url = 'http://{0}:{1}/'.format(*self._endpoint)
 
-        connector = aiohttp.TCPConnector(resolve=True, loop=loop)
-        self._session = aiohttp.ClientSession(connector=connector)
+        self._session = aiohttp.ClientSession(connector=aiohttp.TCPConnector(),
+                                              loop=self._loop)
 
     @property
     def endpoint(self):

--- a/asyncnsq/http/base.py
+++ b/asyncnsq/http/base.py
@@ -12,23 +12,24 @@ class NsqHTTPConnection:
     def __init__(self, host='127.0.0.1', port=4150, *, loop):
         self._loop = loop
         self._endpoint = (host, port)
-        self._connector = aiohttp.TCPConnector(resolve=True, loop=loop)
         self._base_url = 'http://{0}:{1}/'.format(*self._endpoint)
-        self._request = aiohttp.request
+
+        connector = aiohttp.TCPConnector(resolve=True, loop=loop)
+        self._session = aiohttp.ClientSession(connector=connector)
 
     @property
     def endpoint(self):
         return 'http://{0}:{1}'.format(*self._endpoint)
 
     def close(self):
-        self._connector.close()
+        self._session.close()
 
     async def perform_request(self, method, url, params, body):
         _body = _convert_to_str(body) if body else body
         url = self._base_url + url
-        resp = await self._request(method, url, params=params,
-                                   data=_body, loop=self._loop,
-                                   connector=self._connector)
+        resp = await self._session.request(method, url,
+                                           params=params,
+                                           data=_body)
         resp_body = await resp.text()
         try:
             response = json.loads(resp_body)

--- a/asyncnsq/log.py
+++ b/asyncnsq/log.py
@@ -1,4 +1,3 @@
 import logging
 
-logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__package__)


### PR DESCRIPTION
- removed prints — most changed to `logger.debug`
- removed `logger.basicConfig` — libraries should not configure logging
- changed `logger.info` to `logger.debug`
- added `NsqConsumer.messages()` interface to allow message reception via `async for` (Python 3.6 PEP 525)
- added `aiohttp.ClientSession` to `NsqHTTPConnection` to conform with `aiohttp.request` deprecation. Ensured compatibility with aiohttp 3
- changed `asyncio.Task` instantiation, `asyncio.ensure_future` usage to `loop.create_task` — it's the recommended way to create futures according to Guido
- updated RDY redistribution coroutine to make it more async