### PR TITLE
Add a graceful 'unsubscribe' and closing for reader and writer

### DIFF
--- a/asyncnsq/tcp/connection.py
+++ b/asyncnsq/tcp/connection.py
@@ -196,7 +196,7 @@ class TcpConnection:
     async def _read_data(self):
         """Response reader task."""
         is_canceled = False
-        logger.info("{} starting _read_data".format(self))
+        # logger.debug("{} starting _read_data".format(self))
         while not self._reader.at_eof():
             try:
                 data = await self._reader.read(52)

--- a/asyncnsq/tcp/connection.py
+++ b/asyncnsq/tcp/connection.py
@@ -12,7 +12,6 @@ from .protocol import Reader, DeflateReader, SnappyReader
 
 logger = logging.getLogger(__package__)
 
-
 async def create_connection(host='localhost', port=4150,
                             queue=None, loop=None):
     """create nsq tcp connection
@@ -51,7 +50,7 @@ class TcpConnection:
         self._cmd_waiters = deque()
         self._closing = False
         self._closed = False
-        self._reader_task = asyncio.Task(self._read_data(), loop=self._loop)
+        self._reader_task = self._loop.create_task(self._read_data())
         # mark connection in upgrading state to ssl socket
         self._is_upgrading = False
         self._on_message = on_message
@@ -59,9 +58,11 @@ class TcpConnection:
 
         # number of received but not acked or req messages
         self._in_flight = 0
+        logger.info("new connection: {}:{}".format(self._host, self._port))
 
     def connect(self):
         self._send_magic()
+        logger.info("connect: {}:{}".format(self._host, self._port))
 
     def execute(self, command, *args, data=None, cb=None):
         """XXX"""
@@ -114,7 +115,8 @@ class TcpConnection:
 
     def close(self):
         """Close connection."""
-        self._do_close()
+        if not self.closed:
+            self._do_close()
 
     async def identify(self, **config):
         # TODO: add config validator
@@ -140,7 +142,7 @@ class TcpConnection:
         return resp
 
     def _do_close(self, exc=None):
-        print("this is the going close info")
+        logger.info("this is the going close info")
         if exc:
             logger.error("Connection closed with error: {}".format(exc))
         if self._closed:
@@ -172,7 +174,7 @@ class TcpConnection:
         bin_ok = await self._reader.readexactly(10)
         if bin_ok != consts.BIN_OK:
             raise RuntimeError('Upgrade to TLS failed, got: {}'.format(bin_ok))
-        self._reader_task = asyncio.Task(self._read_data(), loop=self._loop)
+        self._reader_task = self._loop.create_task(self._read_data())
         self._reader_task.add_done_callback(self._on_reader_task_stopped)
 
     def _on_reader_task_stopped(self, future):
@@ -194,12 +196,13 @@ class TcpConnection:
     async def _read_data(self):
         """Response reader task."""
         is_canceled = False
+        logger.info("{} starting _read_data".format(self))
         while not self._reader.at_eof():
             try:
                 data = await self._reader.read(52)
             except asyncio.CancelledError:
                 is_canceled = True
-                logger.debug('Task is canceled')
+                logger.debug('Task is canceled {}'.format(self))
                 break
             except Exception as exc:
                 logger.exception(exc)
@@ -276,4 +279,4 @@ class TcpConnection:
         self._is_upgrading = False
 
     def __repr__(self):
-        return '<TcpConnection: {}:{}'.format(self._host, self._port)
+        return '<TcpConnection: {}:{}>'.format(self._host, self._port)

--- a/asyncnsq/tcp/connection.py
+++ b/asyncnsq/tcp/connection.py
@@ -115,8 +115,7 @@ class TcpConnection:
 
     def close(self):
         """Close connection."""
-        if not self.closed:
-            self._do_close()
+        self._do_close()
 
     async def identify(self, **config):
         # TODO: add config validator

--- a/asyncnsq/tcp/connection.py
+++ b/asyncnsq/tcp/connection.py
@@ -55,6 +55,7 @@ class TcpConnection:
         self._is_upgrading = False
         self._on_message = on_message
         self._on_close = None
+        self._on_close_flag = asyncio.Event(loop=self._loop)
 
         # number of received but not acked or req messages
         self._in_flight = 0
@@ -108,6 +109,9 @@ class TcpConnection:
             self._closing = closed = True
             self._loop.call_soon(self._do_close, None)
         return closed
+    
+    async def wait_for_closed(self, timeout=10):
+        await asyncio.wait_for(self._on_close_flag.wait(), timeout, loop=self._loop)
 
     @property
     def queue(self):
@@ -150,6 +154,7 @@ class TcpConnection:
         self._closing = False
         self._writer.transport.close()
         self._reader_task.cancel()
+        self._on_close_flag.set()
 
     def _send_magic(self):
         self._writer.write(consts.MAGIC_V2)

--- a/asyncnsq/tcp/reader.py
+++ b/asyncnsq/tcp/reader.py
@@ -92,7 +92,7 @@ class Reader:
                     loop=self._loop)
                 await self.prepare_conn(conn)
                 self._connections[conn.id] = conn
-            self._rdy_control.add_connections(self._connections)
+            self._rdy_control.add_connections(self._connections) #do we need to close conn in rdy_control?
         # init distribute for conns, init update rdy state for conn
         self._rdy_control.redistribute()
 
@@ -173,3 +173,8 @@ class Reader:
     async def _lookupd(self):
         host, port = random.choice(self._lookupd_http_addresses)
         await self._poll_lookupd(host, port)
+
+
+    def close(self):
+        for conn in self._connections:
+            conn.close()

--- a/asyncnsq/tcp/reader.py
+++ b/asyncnsq/tcp/reader.py
@@ -227,7 +227,8 @@ class Reader:
 
 
     async def cancel(self, timeout = 10):
-        self._is_subscribe = False
+        if self._is_subscribe:
+            await self.unsubscribe()
         try:
             # await self.send_cls()
             # clear rdy_controls

--- a/asyncnsq/tcp/reader.py
+++ b/asyncnsq/tcp/reader.py
@@ -6,7 +6,7 @@ from asyncnsq.http import NsqLookupd
 from asyncnsq.tcp.reader_rdy import RdyControl
 from functools import partial
 from .connection import create_connection
-from .consts import SUB
+from .consts import SUB,RDY,CLS
 
 logger = logging.getLogger(__package__)
 
@@ -68,6 +68,7 @@ class Reader:
 
         self._rdy_control = None
         self._max_in_flight = max_in_flight
+        self._num_readers = 0
 
         self._is_subscribe = False
         self._redistribute_timeout = 5  # sec
@@ -147,6 +148,14 @@ class Reader:
 
     async def sub(self, conn, topic, channel):
         await conn.execute(SUB, topic, channel)
+    
+    async def set_max_in_flight(self, max_in_flight):
+        for conn in self._connections.values():
+            conn.execute(RDY, max_in_flight)
+
+    async def send_cls(self):
+        for conn in self._connections.values():
+            conn.execute(CLS)
 
     def wait_messages(self):
         if not self._is_subscribe:
@@ -159,10 +168,21 @@ class Reader:
     async def messages(self):
         if not self._is_subscribe:
             raise ValueError('You must subscribe to the topic first')
+        
+        try:
+            logger.debug("num readers ++ ")
+            self._num_readers += 1
+            while self._is_subscribe:
+                result = await self._queue.get()
+                if result is not None:
+                    yield result
+                else:
+                    logger.debug("got NONE, skip")
+            logger.debug("leaving message receiving")
+        finally:
+            logger.debug("num readers -- ")
+            self._num_readers -= 1
 
-        while self._is_subscribe:
-            result = await self._queue.get()
-            yield result
 
     async def _redistribute(self):
         while self._is_subscribe:
@@ -173,8 +193,62 @@ class Reader:
     async def _lookupd(self):
         host, port = random.choice(self._lookupd_http_addresses)
         await self._poll_lookupd(host, port)
+    
+    async def unsubscribe(self):
+        if not self._is_subscribe:
+            raise ValueError('You must subscribe to the topic first')
+        logger.debug("unsubscribe starting... in {}".format(__package__))
+        # mark as disabled
+        await self.set_max_in_flight(0)
+        # clear is_subscribed flag
+        self._is_subscribe = False
+        # send None to clear readers
+        while self._num_readers > 0:
+            for i in range(self._num_readers):
+                self._queue.put_nowait(None)
+            await asyncio.sleep(0.05)
+        # no subscribers now
+
+        # clear & req rest of the messages
+        # mostly it is empty
+        try:
+            # consume all unfinished elems
+            while not self._queue.empty():
+                try:
+                    result = self._queue.get_nowait()
+                    if result is not None:
+                        logger.debug("req: {}".format(result))
+                        await result.req(0)
+                except Exception as e:
+                    logger.warning("req message failed {}".format(e))
+        except Exception as e:
+            logger.warning("requeue all messages failed {}".format(e))
 
 
-    def close(self):
-        for conn in self._connections:
-            conn.close()
+    async def cancel(self, timeout = 10):
+        self._is_subscribe = False
+        try:
+            # await self.send_cls()
+            # clear rdy_controls
+            if self._rdy_control is not None:
+                self._rdy_control.stop_working()
+            # close all connections
+            for conn in self._connections.values():
+                conn.close()
+        except Exception as e:
+            logger.error("close failed: {}".format(e))
+
+    def close(self, timeout = 10):
+        time_in = time.time()
+        close_task = self._loop.create_task(self.cancel(timeout))
+        while True:
+            if close_task.cancelled():
+                logger.info("reader closer cancelled..")
+                return
+            if close_task.done():
+                logger.info("reader closer finished..")
+                return
+            now = time.time()
+            if timeout > 0 and now - time_in > timeout:
+                logger.warning("writer closer timeout")
+                return

--- a/asyncnsq/tcp/reader.py
+++ b/asyncnsq/tcp/reader.py
@@ -197,7 +197,7 @@ class Reader:
     async def unsubscribe(self):
         if not self._is_subscribe:
             raise ValueError('You must subscribe to the topic first')
-        logger.debug("unsubscribe starting... in {}".format(__package__))
+        # logger.debug("unsubscribing {}".format(self))
         # mark as disabled
         await self.set_max_in_flight(0)
         # clear is_subscribed flag

--- a/asyncnsq/tcp/reader.py
+++ b/asyncnsq/tcp/reader.py
@@ -5,6 +5,7 @@ import time
 from asyncnsq.http import NsqLookupd
 from asyncnsq.tcp.reader_rdy import RdyControl
 from functools import partial
+from ..utils import retry_iterator
 from .connection import create_connection
 from .consts import SUB,RDY,CLS
 
@@ -93,7 +94,7 @@ class Reader:
                     loop=self._loop)
                 await self.prepare_conn(conn)
                 self._connections[conn.id] = conn
-            self._rdy_control.add_connections(self._connections) #do we need to close conn in rdy_control?
+            self._rdy_control.add_connections(self._connections)
         # init distribute for conns, init update rdy state for conn
         self._rdy_control.redistribute()
 
@@ -241,6 +242,7 @@ class Reader:
     def close(self, timeout = 10):
         time_in = time.time()
         close_task = self._loop.create_task(self.cancel(timeout))
+        timeout_generator = retry_iterator(init_delay=0.01, max_delay=1.0)
         while True:
             if close_task.cancelled():
                 logger.info("reader closer cancelled..")
@@ -252,3 +254,5 @@ class Reader:
             if timeout > 0 and now - time_in > timeout:
                 logger.warning("writer closer timeout")
                 return
+            t = next(timeout_generator)
+            time.sleep(t)

--- a/asyncnsq/tcp/reader.py
+++ b/asyncnsq/tcp/reader.py
@@ -5,7 +5,7 @@ import time
 from asyncnsq.http import NsqLookupd
 from asyncnsq.tcp.reader_rdy import RdyControl
 from functools import partial
-from ..utils import retry_iterator
+# from ..utils import retry_iterator
 from .connection import create_connection
 from .consts import SUB,RDY,CLS
 
@@ -226,7 +226,7 @@ class Reader:
             logger.warning("requeue all messages failed {}".format(e))
 
 
-    async def cancel(self, timeout = 10):
+    async def close(self):
         if self._is_subscribe:
             await self.unsubscribe()
         try:
@@ -240,20 +240,21 @@ class Reader:
         except Exception as e:
             logger.error("close failed: {}".format(e))
 
-    def close(self, timeout = 10):
-        time_in = time.time()
-        close_task = self._loop.create_task(self.cancel(timeout))
-        timeout_generator = retry_iterator(init_delay=0.01, max_delay=1.0)
-        while True:
-            if close_task.cancelled():
-                logger.info("reader closer cancelled..")
-                return
-            if close_task.done():
-                logger.info("reader closer finished..")
-                return
-            now = time.time()
-            if timeout > 0 and now - time_in > timeout:
-                logger.warning("writer closer timeout")
-                return
-            t = next(timeout_generator)
-            time.sleep(t)
+    # it will cause complex issue
+    # def close(self, timeout = 10):
+    #     time_in = time.time()
+    #     close_task = self._loop.create_task(self.cancel(timeout))
+    #     timeout_generator = retry_iterator(init_delay=0.01, max_delay=1.0)
+    #     while True:
+    #         if close_task.cancelled():
+    #             logger.info("reader closer cancelled..")
+    #             return
+    #         if close_task.done():
+    #             logger.info("reader closer finished..")
+    #             return
+    #         now = time.time()
+    #         if timeout > 0 and now - time_in > timeout:
+    #             logger.warning("writer closer timeout")
+    #             return
+    #         t = next(timeout_generator)
+    #         time.sleep(t)

--- a/asyncnsq/tcp/reader_rdy.py
+++ b/asyncnsq/tcp/reader_rdy.py
@@ -4,6 +4,7 @@ import random
 from .consts import RDY
 REDISTRIBUTE = 0
 CHANGE_CONN_RDY = 1
+NOOP = 2
 
 
 class RdyControl:
@@ -45,6 +46,8 @@ class RdyControl:
                 await self._redistribute_rdy_state()
             elif cmd == CHANGE_CONN_RDY:
                 await self._update_rdy(*args)
+            elif cmd == NOOP:
+                continue
             else:
                 RuntimeError("Should never be here")
 
@@ -53,6 +56,11 @@ class RdyControl:
 
     def remove_all(self):
         self._connections = {}
+    
+    def stop_working(self):
+        self._is_working = False
+        self._cmd_queue.put_nowait((NOOP, ()))
+        self.remove_all()
 
     async def _redistribute_rdy_state(self):
         # We redistribute RDY counts in a few cases:

--- a/asyncnsq/tcp/writer.py
+++ b/asyncnsq/tcp/writer.py
@@ -218,6 +218,7 @@ class Writer:
     def close(self, timeout = 10):
         time_in = time.time()
         close_task = self._loop.create_task(self.cancel(timeout))
+        timeout_generator = retry_iterator(init_delay=0.01, max_delay=1.0)
         while True:
             if close_task.cancelled():
                 logger.info("writer closer cancelled..")
@@ -229,6 +230,8 @@ class Writer:
             if timeout > 0 and now - time_in > timeout:
                 logger.warning("writer closer timeout")
                 return
+            t = next(timeout_generator)
+            time.sleep(t)
 
     def __repr__(self):
         return '<Writer{}>'.format(self._conn.__repr__())

--- a/asyncnsq/tcp/writer.py
+++ b/asyncnsq/tcp/writer.py
@@ -62,8 +62,9 @@ class Writer:
         self._status = consts.INIT
         self._on_rdy_changed_cb = None
         self._is_working = True
-        self._auto_reconnect_task_closed = False
+        self._auto_reconnect_task_closed = asyncio.Event(loop=self._loop)
         self._auto_reconnect_task = self._loop.create_task(self.auto_reconnect())
+        self._exit_event = asyncio.Event(loop=self._loop)
 
     async def connect(self):
         logger.debug("writer init connect")
@@ -124,7 +125,7 @@ class Writer:
         except asyncio.CancelledError:
             logger.info("{} auto_reconnect cancelled".format(self))
         finally:
-            self._auto_reconnect_task_closed = True
+            self._auto_reconnect_task_closed.set()
             try:
                 if self._conn and not self._conn.closed:
                     self._conn.close()
@@ -196,42 +197,40 @@ class Writer:
     def id(self):
         return self._conn.endpoint
 
-    async def cancel(self, timeout = 10):
+    async def close(self, timeout = 10):
         time_in = time.time()
         self._is_working = False
         self._conn.close()
-        while not self._conn.closed:
-            await asyncio.sleep(0.1, loop=self._loop)
-            now = time.time()
-            if timeout > 0 and now - time_in > timeout:
-                logger.warning("close failed: timeout")
-        logger.info("closing _auto_reconnect_task")
         self._status = consts.CLOSED
+        try:
+            await self._conn.wait_for_closed()
+        except asyncio.TimeoutError:
+            logger.warning("closing current connection failed: timeout")
+        
         self._auto_reconnect_task.cancel()
-        while not self._auto_reconnect_task_closed:
-            await asyncio.sleep(0.1, loop=self._loop)
-            now = time.time()
-            if timeout > 0 and now - time_in > timeout:
-                logger.warning("cancel failed: timeout")
-        logger.info("_auto_reconnect_task_closed = {}".format(self._auto_reconnect_task_closed))
+        try:
+            await asyncio.wait_for(self._auto_reconnect_task_closed.wait(), timeout=timeout, loop=self._loop)
+        except asyncio.TimeoutError:
+            logger.warning("cancel auto_reconnect_task failed: timeout")
+        logger.info("auto_reconnect_task closed")
 
-    def close(self, timeout = 10):
-        time_in = time.time()
-        close_task = self._loop.create_task(self.cancel(timeout))
-        timeout_generator = retry_iterator(init_delay=0.01, max_delay=1.0)
-        while True:
-            if close_task.cancelled():
-                logger.info("writer closer cancelled..")
-                return
-            if close_task.done():
-                logger.info("writer closer finished..")
-                return
-            now = time.time()
-            if timeout > 0 and now - time_in > timeout:
-                logger.warning("writer closer timeout")
-                return
-            t = next(timeout_generator)
-            time.sleep(t)
+    # def close(self, timeout = 10):
+    #     time_in = time.time()
+    #     close_task = self._loop.create_task(self.cancel(timeout))
+    #     timeout_generator = retry_iterator(init_delay=0.01, max_delay=1.0)
+    #     while True:
+    #         if close_task.cancelled():
+    #             logger.info("writer closer cancelled..")
+    #             return
+    #         if close_task.done():
+    #             logger.info("writer closer finished..")
+    #             return
+    #         now = time.time()
+    #         if timeout > 0 and now - time_in > timeout:
+    #             logger.warning("writer closer timeout")
+    #             return
+    #         t = next(timeout_generator)
+    #         time.sleep(t)
 
     def __repr__(self):
         return '<Writer{}>'.format(self._conn.__repr__())

--- a/asyncnsq/tcp/writer.py
+++ b/asyncnsq/tcp/writer.py
@@ -61,7 +61,9 @@ class Writer:
         self._queue = queue or asyncio.Queue(loop=self._loop)
         self._status = consts.INIT
         self._on_rdy_changed_cb = None
-        self._loop.create_task(self.auto_reconnect())
+        self._is_working = True
+        self._auto_reconnect_task_closed = False
+        self._auto_reconnect_task = self._loop.create_task(self.auto_reconnect())
 
     async def connect(self):
         logger.debug("writer init connect")
@@ -102,22 +104,34 @@ class Writer:
     async def auto_reconnect(self):
         logger.debug("writer autoreconnect")
         timeout_generator = retry_iterator(init_delay=0.1, max_delay=10.0)
-        while True:
-            logger.debug("autoreconnect check loop")
-            if not (self._status == consts.CONNECTED):
-                logger.debug(
-                    f"writer close({self._status})detected,reconnect")
-                conn_id = self.id if self._conn else 'init'
-                logger.info('reconnect writer{}'.format(conn_id))
-                try:
-                    await self.reconnect()
-                except ConnectionError:
-                    logger.error("Can not connect to: {}:{} ".format(
-                        self._host, self._port))
-                else:
-                    self._status = consts.CONNECTED
-            t = next(timeout_generator)
-            await asyncio.sleep(t, loop=self._loop)
+        try:
+            while self._is_working:
+                logger.debug("writer autoreconnect check loop")
+                if not (self._status == consts.CONNECTED or self._status == consts.INIT):
+                    logger.debug(
+                        f"writer close({self._status})detected,reconnect")
+                    conn_id = self.id if self._conn else 'init'
+                    logger.info('reconnect writer{}'.format(conn_id))
+                    try:
+                        await self.reconnect()
+                    except ConnectionError:
+                        logger.error("Can not connect to: {}:{} ".format(
+                            self._host, self._port))
+                    else:
+                        self._status = consts.CONNECTED
+                t = next(timeout_generator)
+                await asyncio.sleep(t, loop=self._loop)
+        except asyncio.CancelledError:
+            logger.info("{} auto_reconnect cancelled".format(self))
+        finally:
+            self._auto_reconnect_task_closed = True
+            try:
+                if self._conn and not self._conn.closed:
+                    self._conn.close()
+            except Exception as tmp:
+                logger.info(
+                    'conn close failed,maybe its closed already or init')
+                logger.exception(tmp)
 
     async def execute(self, command, *args, data=None):
         if self._conn.closed:
@@ -182,9 +196,39 @@ class Writer:
     def id(self):
         return self._conn.endpoint
 
-    def close(self):
+    async def cancel(self, timeout = 10):
+        time_in = time.time()
+        self._is_working = False
         self._conn.close()
+        while not self._conn.closed:
+            await asyncio.sleep(0.1, loop=self._loop)
+            now = time.time()
+            if timeout > 0 and now - time_in > timeout:
+                logger.warning("close failed: timeout")
+        logger.info("closing _auto_reconnect_task")
         self._status = consts.CLOSED
+        self._auto_reconnect_task.cancel()
+        while not self._auto_reconnect_task_closed:
+            await asyncio.sleep(0.1, loop=self._loop)
+            now = time.time()
+            if timeout > 0 and now - time_in > timeout:
+                logger.warning("cancel failed: timeout")
+        logger.info("_auto_reconnect_task_closed = {}".format(self._auto_reconnect_task_closed))
+
+    def close(self, timeout = 10):
+        time_in = time.time()
+        close_task = self._loop.create_task(self.cancel(timeout))
+        while True:
+            if close_task.cancelled():
+                logger.info("writer closer cancelled..")
+                return
+            if close_task.done():
+                logger.info("writer closer finished..")
+                return
+            now = time.time()
+            if timeout > 0 and now - time_in > timeout:
+                logger.warning("writer closer timeout")
+                return
 
     def __repr__(self):
         return '<Writer{}>'.format(self._conn.__repr__())


### PR DESCRIPTION
This PR includes some updates as follow: 

+ Added an async function `unsubscribe` for TCP Reader to move all subscribers out
+ Added an async function `cancel` for TCP Reader and Writer to safely close the connections
+ Added a `close` for TCP Reader and Writer to call the `cancel` function and waiting for them closed
+ Fixed a bug in regarding to TCP Writer's auto-reconnecting. It will try to connect to the TCP server before called `connect`. Besides, if we use `create_writer` since there is a gap from `consts.INIT` to `consts.CONNECTED`, it will always incorrectly treat the 1st connecting 'failed', and cancel the 1st attempting before its succeeded

