### PR TITLE
more auth tests, closing down connections

### DIFF
--- a/asyncnsq/http/auth.py
+++ b/asyncnsq/http/auth.py
@@ -18,7 +18,20 @@ async def create_auth_server(auth_secret, loop=None):
 
 def create_dev_auth_server(argv):
     auth_server = AuthServer()
+
     auth_server.add_client('test_secret', 'test_client_id', remote_ip='127.0.0.1', tls=False)
+    auth_server.add_client('test_ip', 'test_client_id', remote_ip='127.0.0.2', tls=False)
+    auth_server.add_client('test_tls', 'test_client_id', remote_ip='127.0.0.1', tls=True)
+
+    auths = [auth_server.make_auth(permissions=['subscribe'])]
+    auth_server.add_client('test_no_pub', 'test_client_id', remote_ip='127.0.0.1', tls=False, auths=auths)
+    auths = [auth_server.make_auth(permissions=['publish'])]
+    auth_server.add_client('test_no_sub', 'test_client_id', remote_ip='127.0.0.1', tls=False, auths=auths)
+    auths = [auth_server.make_auth(topic='test_topic')]
+    auth_server.add_client('test_topic', 'test_client_id', remote_ip='127.0.0.1', tls=False, auths=auths)
+    auths = [auth_server.make_auth(channels=['test_channel'])]
+    auth_server.add_client('test_channel', 'test_client_id', remote_ip='127.0.0.1', tls=False, auths=auths)
+
     return auth_server.make_app()
 
 
@@ -69,7 +82,7 @@ class AuthServer:
         if remote_ip and remote_ip != self._client_auths[secret]['remote_ip']:
             raise aiohttp.web.HTTPUnauthorized
 
-        if tls and tls != self._client_auths[secret]['tls']:
+        if tls is not None and tls != self._client_auths[secret]['tls']:
             raise aiohttp.web.HTTPUnauthorized
 
         client_auth = self._client_auths[secret]['auth']

--- a/asyncnsq/tcp/connection.py
+++ b/asyncnsq/tcp/connection.py
@@ -248,7 +248,7 @@ class TcpConnection:
                 waiter, cb = self._cmd_waiters.popleft()
                 error = make_error(*resp)
                 if not waiter.cancelled():
-                    waiter.set_result(resp)
+                    waiter.set_exception(error)
                     cb is not None and cb(resp)
             elif resp_type == consts.FRAME_TYPE_MESSAGE:
 

--- a/asyncnsq/tcp/reader_rdy.py
+++ b/asyncnsq/tcp/reader_rdy.py
@@ -101,3 +101,8 @@ class RdyControl:
         # get the max rdy state for conn
         rdy_state = int(max(1, base_conn_max_in_flight - conn_in_flight))
         await conn.execute(RDY, rdy_state)
+
+    def close(self):
+        self._distributor_task.cancel()
+        for conn in self._connections.values():
+            conn.close()

--- a/tests/test_reader_and_writer.py
+++ b/tests/test_reader_and_writer.py
@@ -1,7 +1,13 @@
 import asyncio
-from ._testutils import run_until_complete, BaseTest
+import json
+
+from asyncnsq.tcp.connection import create_connection
+from asyncnsq.tcp.exceptions import ReaderError, WriterError
 from asyncnsq.tcp.reader import create_reader
 from asyncnsq.tcp.writer import create_writer
+from asyncnsq.utils import _convert_to_str
+
+from ._testutils import run_until_complete, BaseTest
 
 
 class NsqTest(BaseTest):
@@ -27,6 +33,7 @@ class NsqTest(BaseTest):
         for i in range(10):
             pub_res = await nsq.pub('foo', 'bar')
             self.assertEqual(pub_res, b"OK")
+        nsq.close()
 
     @run_until_complete
     async def test_02_reader(self):
@@ -46,5 +53,43 @@ class NsqTest(BaseTest):
             num += 1
             fin_res = await msg.fin()
             self.assertEqual(fin_res, b"OK")
-            if num > 10:
+            if num >= 10:
                 break
+        nsq.close()
+
+    async def _is_auth_required(self):
+        conn = await create_connection(
+            host=self.host,
+            port=self.port,
+            loop=self.loop
+        )
+        res = await conn.identify(feature_negotiation=True)
+        res = json.loads(_convert_to_str(res))
+        auth_required = res.get('auth_required') or False
+        conn.close()
+        return res
+
+    @run_until_complete
+    async def test_03_writer_fail_missing_secret(self):
+        if await self._is_auth_required():
+            with self.assertRaises(WriterError):
+                nsq = await create_writer(
+                    host=self.host,
+                    port=self.port,
+                    feature_negotiation=True,
+                    loop=self.loop
+                )
+        else:
+            self.skipTest("no auth enabled")
+
+    @run_until_complete
+    async def test_04_reader_fail_missing_secret(self):
+        if await self._is_auth_required():
+            with self.assertRaises(ReaderError):
+                nsq = await create_reader(
+                    nsqd_tcp_addresses=[f"{self.host}:{self.port}"],
+                    feature_negotiation=True,
+                    loop=self.loop
+                )
+        else:
+            self.skipTest("no auth enabled")


### PR DESCRIPTION
added the requested tests:

- nsq requires auth but client have none
- nsq requires none, but client have one , (**this happens when you run the nsqd command without auth info**)
- auth key is wrong

I've also added some cleanup to the TCP connections and async tasks, since some were lingering esp. after running the tests. eventually could be nice to set up a context manager for reader/writer/connection which would close on exit, similar to how file opening works.